### PR TITLE
Adds BaseRepository generation to the make:repository command

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,11 @@
     "globals": {
         "describe": true,
         "afterAll": true,
+        "beforeAll": true,
         "expect": true,
         "test": true
+    },
+    "rules": {
+        "no-console": 0
     }
 }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ npm i -g netsells/crayon-cli
 
      <name>      Repository name      required      
 
+   OPTIONS
+
+     --with-base          Whether the BaseRepository should be recreated.                 optional      
+     --overwrite, -o      Whether the repository should be overwritten if it exists.      optional      
+
    GLOBAL OPTIONS
 
      -h, --help         Display help                                      

--- a/commands/make-repository/index.js
+++ b/commands/make-repository/index.js
@@ -1,20 +1,58 @@
 const crayon = require('caporal');
-const fs = require('fs-extra');
+const { outputFileSync, readFileSync, existsSync } = require('fs-extra');
 const path = require('path');
 const chalk = require('chalk');
+const glob = require('glob');
 const { toCamelCase } = require('../../utils');
 const { generateOutputPath, generateRepositoryName } = require('./utils');
+const { template } = require('lodash');
+const baseRepositoryPath = path.resolve(`${__dirname}/stubs/BaseRepository.js`);
+
+/**
+ * Create the BaseRepository file
+ *
+ * @param {Object} data
+ */
+const makeBaseRepository = (data) => {
+    const baseRepositoryTemplate = readFileSync(baseRepositoryPath, 'utf8');
+
+    const baseRepositoryStub = template(baseRepositoryTemplate)({
+        laroute_path: path.relative(generateOutputPath('Base'), data.laroutePath),
+    });
+
+    // Create the base repository
+    outputFileSync(generateOutputPath('Base'), baseRepositoryStub);
+};
 
 crayon.command('make:repository', 'Make a repository')
     .argument('<name>', 'Repository name')
+    .option('--with-base', 'Whether the BaseRepository should be recreated.')
+    .option('--overwrite, -o', 'Whether the repository should be overwritten if it exists.')
     .action((args, options, logger) => {
-        const stub = fs.readFileSync(path.resolve(`${__dirname}/stubs/StubRepository.js`), 'utf8');
-        const entityName = toCamelCase(args.name);
+        let baseCreated = false;
         const repositoryName = generateRepositoryName(args.name);
+
+        // Find where the routes file is
+        const laroutePath = glob.sync('./public/**/laroute.js')[0];
+        if (!laroutePath) {
+            return console.log(chalk.red('Laroute not found in the current project.'));
+        }
+
+        if (existsSync(generateOutputPath(args.name)) && !options.overwrite) {
+            return console.log(chalk.red(`${repositoryName} exists. To overwrite, provide the [-o, --overwrite] flag.`));
+        }
+        /** @type {String} */
+        const stub = readFileSync(path.resolve(`${__dirname}/stubs/StubRepository.js`), 'utf8');
+        const entityName = toCamelCase(args.name);
         const repositoryContent = stub.replace(new RegExp('Stub', 'g'), entityName);
 
-        // Create the file
-        fs.outputFileSync(generateOutputPath(args.name), repositoryContent);
-        
-        logger.info(chalk.green(`${repositoryName} created successfully.`));
+        if (options.withBase || !existsSync(generateOutputPath('Base'))) {
+            makeBaseRepository({ laroutePath });
+            baseCreated = true;
+        }
+
+        // Create the new repository
+        outputFileSync(generateOutputPath(args.name), repositoryContent);
+
+        logger.info(chalk.green(`${(baseCreated) ? 'BaseRepository and ' : ''}${repositoryName} created successfully.`));
     });

--- a/commands/make-repository/stubs/BaseRepository.js
+++ b/commands/make-repository/stubs/BaseRepository.js
@@ -1,0 +1,94 @@
+import routes from '<%- laroute_path %>';
+import axios from 'axios';
+
+class BaseRepository {
+
+    /**
+     * Construct the repository
+     * We provide axios, all routes and the route helper
+     * to the global repository context here
+     */
+    constructor() {
+        this.routes = routes;
+        this.route = routes.route;
+        this.axios = axios;
+    }
+
+    /**
+     * Standard get request
+     *
+     * @param {object} url
+     * @param {object} data
+     *
+     * @return {Promise}
+     */
+    get(url, data) {
+        return this.request('get', url, data);
+    }
+
+    /**
+     * Standard patch request
+     *
+     * @param {object} url
+     * @param {object} data
+     *
+     * @return {Promise}
+     */
+    patch(url, data) {
+        return this.request('patch', url, data);
+    }
+
+
+    /**
+     * Standard post request
+     *
+     * @param {object} url
+     * @param {object} data
+     *
+     * @return {Promise}
+     */
+    post(url, data) {
+        return this.request('post', url, data);
+    }
+
+
+    /**
+     * Standard delete request
+     *
+     * @param {object} url
+     * @param {object} data
+     *
+     * @return {Promise}
+     */
+    delete(url, data) {
+        return this.request('delete', url, data);
+    }
+
+
+    /**
+     * Standard request handler
+     *
+     * @param {object} method
+     * @param {object} url
+     * @param {object} data
+     *
+     * @return {Promise}
+     */
+    request(method, url, data) {
+        return this.axios[method](url, data)
+            .then(this.normaliseResponse)
+    }
+
+    /**
+     * Normalise the response and return just the data
+     *
+     * @param { object } data
+     * @return {string} data
+     */
+    normaliseResponse({ data }) {
+        return data;
+    }
+
+}
+
+export default BaseRepository;

--- a/commands/make-repository/utils.js
+++ b/commands/make-repository/utils.js
@@ -5,22 +5,22 @@ const OUTPUT_DIRECTORY = `${js_directory}/repositories`;
 /**
  * Generate the name of the repository
  *
- * @param name
+ * @param {String} name
  *
  * @returns {string}
  */
-function generateRepositoryName (name) {
+function generateRepositoryName(name) {
     return `${toCamelCase(name)}Repository`;
 }
 
 /**
  * Generate the fully formed output path of the repository file
  *
- * @param name
+ * @param {String} name
  *
  * @returns {string}
  */
-function generateOutputPath (name) {
+function generateOutputPath(name) {
     return `${OUTPUT_DIRECTORY}/${generateRepositoryName(name)}.js`;
 }
 

--- a/dev/generate-readme/index.js
+++ b/dev/generate-readme/index.js
@@ -1,6 +1,7 @@
-const fs = require('fs');
+const { readFileSync, writeFileSync } = require('fs-extra');
 const execute = require('../../utils/execute');
-const templateFile = fs.readFileSync(`${__dirname}/README.md`, 'utf8');
+/** @type {String} */
+const templateFile = readFileSync(`${__dirname}/README.md`, 'utf8');
 const outputFile = `${__dirname}/../../README.md`;
 
 // Run the command and get the output
@@ -9,5 +10,5 @@ execute('crayon --no-color').then((commandOutput) => {
     const output = templateFile.replace('{{CRAYON_OUTPUT}}', commandOutput);
 
     // Write the file
-    fs.writeFileSync(outputFile, output);
+    writeFileSync(outputFile, output);
 });

--- a/dev/make-command/index.js
+++ b/dev/make-command/index.js
@@ -1,14 +1,23 @@
 const slug = require('slug');
-const fs = require('fs-extra');
+const { readFileSync, existsSync, outputFileSync } = require('fs-extra');
 const inquirer = require('inquirer');
 const chalk = require('chalk');
-const commandStub = fs.readFileSync(`${__dirname}/stubs/command.js`, 'utf8');
-const testStub = fs.readFileSync(`${__dirname}/stubs/test.js`, 'utf8');
+
+/** @type {string} */
+const commandStub = readFileSync(`${__dirname}/stubs/command.js`, 'utf8');
+/** @type {string} */
+const testStub = readFileSync(`${__dirname}/stubs/test.js`, 'utf8');
 
 // Replace colons with hyphens
 slug.charmap[':'] = '-';
 
-// Generate a the output path for the command
+/**
+ * Generate a the output path for the command
+ *
+ * @param {String} command
+ *
+ * @returns {string}
+ */
 const commandDirectory = (command) => `${process.cwd()}/commands/${slug(command)}`;
 
 inquirer.prompt([
@@ -16,14 +25,14 @@ inquirer.prompt([
         type: 'input',
         name: 'command',
         message: 'What is the command?',
-        validate(value) {
-            if (!Boolean(value.length)) {
+        validate(value) { // eslint-disable-line require-jsdoc-except/require-jsdoc
+            if (!value.length) {
                 return 'Please enter a command.';
             }
             if (value.includes(' ')) {
                 return 'The command should not contain any spaces.';
             }
-            if (fs.existsSync(commandDirectory(value))) {
+            if (existsSync(commandDirectory(value))) {
                 return 'Rule already exists';
             }
 
@@ -34,8 +43,8 @@ inquirer.prompt([
         type: 'input',
         name: 'description',
         message: 'Describe what the command does:',
-        validate(value) {
-            if (!Boolean(value.length)) {
+        validate(value) { // eslint-disable-line require-jsdoc-except/require-jsdoc
+            if (!value.length) {
                 return 'Please enter a description.';
             }
 
@@ -51,14 +60,14 @@ inquirer.prompt([
         .replace('{{DESCRIPTION}}', description);
 
     // Write the command file with basic command boilerplate
-    fs.outputFileSync(`${outputDirectory}/index.js`, output);
+    outputFileSync(`${outputDirectory}/index.js`, output);
 
     // Generate the test boilerplate
     const testOutput = testStub
         .replace(/{{COMMAND}}/g, command);
 
     // Write the test file with basic failing test boilerplate
-    fs.outputFileSync(`./tests/${slug(command)}.test.js`, testOutput);
+    outputFileSync(`./tests/${slug(command)}.test.js`, testOutput);
     
-    console.log('\n' + chalk.green(`Command [${command}] created successfully.`));
+    console.log(`\n${  chalk.green(`Command [${command}] created successfully.`)}`);
 });

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "caporal": "^0.10.0",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.2",
-    "inquirer": "^5.1.0"
+    "inquirer": "^5.1.0",
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
     "eslint": "^4.10.0",

--- a/tests/make-repository.test.js
+++ b/tests/make-repository.test.js
@@ -1,22 +1,47 @@
 const { generateOutputPath, generateRepositoryName } = require('../commands/make-repository/utils');
+/** @type {Object} **/
 const fs = require('fs-extra');
+/** @type {Promise} **/
 const exec = require('../utils/execute');
+const { testPath } = require('../utils');
 const repositoryName = 'user';
-const outputPath = generateOutputPath(repositoryName);
+const repositoryOutputPath = generateOutputPath(repositoryName);
+const baseRepositoryOutputPath = generateOutputPath('Base');
+const laroutePath = testPath('public/js/laroute.js');
+const command = `crayon make:repository ${repositoryName}`;
 
 describe('make:repository', () => {
 
-    afterAll(() => {
-        fs.unlink(outputPath);
+    beforeAll(() => {
+        fs.outputFileSync(laroutePath, '');
     });
 
-    test('generates boilerplate', () => {
+    afterAll(() => {
+        [repositoryOutputPath, baseRepositoryOutputPath, laroutePath].forEach((path) => {
+            if (fs.existsSync(path)) {
+                fs.unlink(path);
+            }
+        });
+    });
+
+    test('generates repository boilerplate', () => {
         expect.assertions(2);
 
-        return exec(`crayon make:repository ${repositoryName}`).then((output) => {
-            const fileExists = fs.existsSync(outputPath);
+        return exec(`${command} -o`).then((output) => {
+            const fileExists = fs.existsSync(repositoryOutputPath);
 
             expect(output).toMatch(new RegExp(`${generateRepositoryName(repositoryName)} created successfully.`));
+            expect(fileExists).toBe(true);
+        });
+    });
+
+    test('generates BaseRepository', () => {
+        expect.assertions(2);
+
+        return exec(`${command} --with-base -o`).then((output) => {
+            const fileExists = fs.existsSync(baseRepositoryOutputPath);
+
+            expect(output).toMatch(new RegExp(`${generateRepositoryName('Base')} and ${generateRepositoryName(repositoryName)} created successfully.`));
             expect(fileExists).toBe(true);
         });
     });

--- a/utils/execute.js
+++ b/utils/execute.js
@@ -9,7 +9,9 @@ const { exec } = require('child_process');
  */
 const execute = (command) => {
     return new Promise((resolve, reject) => {
-        exec(command, (error, stdout, stderr) => { 
+        exec(command, {
+            cwd: './test',
+        }, (error, stdout, stderr) => {
             if (error) {
                 return reject({ error, stderr });
             }

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 /**
  * Convert a string to upper camelcase
  *
@@ -10,4 +12,15 @@ module.exports.toCamelCase = (string) => {
     return string.replace(/\b(\w)/g, (match, capture) => {
         return capture.toUpperCase();
     }).replace(/\s+/g, '');
+};
+
+/**
+ * Generate the test path to a file if provided
+ *
+ * @param {string?} file
+ *
+ * @return {string}
+ */
+module.exports.testPath = (file) => {
+    return path.resolve('./test', file);
 };


### PR DESCRIPTION
Previously the `make:repository` command referenced the `BaseRepository` but it may not yet exist in the project. This addition generates said file.

It comes with a few options: 
`-o`/`--overwrite` - will overwrite the Repository if it exists
`--with-base` - will overwrite the `BaseRepository` 

This addition assumes laroute is being used in the project (it should be IMO) - if this becomes an issues for other projects we can add logic to cater for this. It will currently halt execution if not available or it cannot find the routes file.

It also assumes axios is being used, which in most newer cases it will be, and again can be catered for later down the line. Lodash templating is being used here, so more conditionals can be added for all of these things.

Tests added for checking the `BaseRepository` was created.

Closes #2 